### PR TITLE
Add bolt interface for bolt-train-api

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  forge_modules:
+    facts:
+      repo: "puppetlabs/ruby_task_helper"
+      ref: "0.4.0"

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Module dependency test fixtures
+/spec/fixtures/modules/
+/spec/fixtures/manifests/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,93 @@
+AllCops:
+  TargetRubyVersion: 2.3
+  Exclude:
+    - 'vendor/**/*'
+    - 'vendored/**/*'
+    - 'acceptance/vendor/**/*'
+    - 'modules/**/*'
+    - 'docs/**/*'
+    - 'site-modules/**/*'
+    - 'spec/fixtures/modules/**/*'
+
+# Checks for if and unless statements that would fit on one line if written as a
+# modifier if/unless.
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/AccessModifierDeclarations:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/StderrPuts:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+# Disable nearly all Metrics checks. These seem better off left to judgement.
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+# Enforce LF line endings, even when on Windows
+Layout/EndOfLine:
+  EnforcedStyle: lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+cache: bundler
+rvm:
+- 2.5
+
+before_install:
+- docker-compose -f spec/docker-compose.yml up -d --build
+
+script:
+- bundle exec rubocop
+- bundle exec rake spec
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+def location_for(place_or_version, fake_version = nil)
+  if place_or_version =~ /\A(git[:@][^#]*)#(.*)/
+    [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
+  elsif place_or_version =~ %r{\Afile:\/\/(.*)}
+    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
+  else
+    [place_or_version, { require: false }]
+  end
+end
+
+# Dependencies used by Rake to ship the module
+
+ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
+minor_version = ruby_version_segments[0..1].join('.')
+
+group :development do
+  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
+  gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
+  # Pin puppet blacksmith to avoid failures in forge module push job
+  gem "bolt", "~> 1"
+  gem "puppet-blacksmith", "4.1.2"
+end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,98 @@
-# bolt_train
-Bolt interface for [bolt-train-api](https://github.com/puppetlabs/bolt-train-api)
+# Control Bolt train with Bolt
+
+This module contains bolt tasks and plans for building a control route for the Bolt Train.
+
+## Example
+The following example shows how to compose the `bolt_train` module content to build and submit a route for the train.
+
+The first step is to download the module. Create a new [bolt project](https://puppet.com/docs/bolt/latest/bolt_project_directories.html) and add the following `Puppetfile` to the bolt project (note I will simply add an empty `bolt.yaml` in my example directory. 
+
+```
+# Puppetfile
+mod 'bolt_train',
+  :git => 'https://github.com/puppetlabs/bolt_train'  
+```
+Next, create an [inventoryfile](https://puppet.com/docs/bolt/latest/inventory_file_v2.html) with a remote target configured to connect to the bolt-train-api server.
+
+```yaml
+# inventory.yaml
+version: 2
+targets:
+  - name: bolt-train
+    config:
+      transport: remote
+      remote:
+        train_api_url: https://localhost:5000
+```
+Now create a plan that composes the tasks and plans in the bolt_spec module:
+```puppet
+# myplan.pp
+steps:
+  - name: session_token
+    description: Obtaining BoltTrain token with bolt_train::session_token plan.
+    plan: bolt_train::session_token
+    parameters:
+      email: cas.donoghue@puppet.com
+      targets: bolt-train
+  - name: forward
+    description: Move train forward with the bolt_train::move task. 
+    task: bolt_train::move
+    target: bolt-train
+    parameters:
+      token: $session_token
+      direction: forward
+      speed: 10
+      time: 15
+  - name: run
+    description: Deploy my plan to the train!
+    task: bolt_train::run
+    target: bolt-train
+    parameters:
+      token: $session_token
+```
+The first step is to request a session token. This is accomplished by using the `bolt_train::session_token` plan. That plan will use the `bolt_train::session` task to request a session token, parse the result and return the parsed token. Next the `bolt_train::move` task is used to make the train move forward. Any number of move steps can be added next. Finally the plan has a step to call the `bolt_train::run` task which will finalize the route and submit to the bolt train executor.
+
+Now that the files are in place download the train module with `bolt puppetfile install` which will add the `modules` directory with the `bolt_train` module. The final directory structure should look like:
+```
+cas@cas-ThinkPad-T460p:~/working_dir/bolt_train_example$ tree
+.
+├── bolt.yaml
+├── inventory.yaml
+├── modules
+│   └── bolt_train
+│       ├── lib
+│       │   └── request_helper.rb
+│       ├── plans
+│       │   └── session_token.pp
+│       └── tasks
+│           ├── move.json
+│           ├── move.rb
+│           ├── run.json
+│           ├── run.rb
+│           ├── session.json
+│           └── session.rb
+├── Puppetfile
+└── site-modules
+    └── train_route
+        └── plans
+            └── myplan.yaml
+
+8 directories, 12 files
+```
+## Run the example plan
+```
+cas@cas-ThinkPad-T460p:~/working_dir/bolt_train_example$ bolt plan run train_route::myplan
+Starting: plan train_route::myplan
+Starting: plan bolt_train::session_token
+Starting: task bolt_train::session on bolt-train
+Finished: task bolt_train::session with 0 failures in 0.23 sec
+Finished: plan bolt_train::session_token in 0.23 sec
+Starting: Move train forward with the bolt_train::move task. on bolt-train
+Finished: Move train forward with the bolt_train::move task. with 0 failures in 0.23 sec
+Starting: Deploy my plan to the train! on bolt-train
+Finished: Deploy my plan to the train! with 0 failures in 0.22 sec
+Finished: plan train_route::myplan in 0.69 sec
+Plan completed successfully with no result
+```
+
+## Compose your own plans and extent the tasks!

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?

--- a/lib/request_helper.rb
+++ b/lib/request_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'openssl'
+
+module RequestHelper
+  class << self
+    def request(uri, body, token = nil)
+      uri = URI(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      headers = { 'Content-type' => 'application/json' }
+      # /session/create does not require token
+      headers['Authorization'] = "Bearer #{token}" if token
+      req = Net::HTTP::Post.new(uri, headers)
+      req.body = body.to_json
+
+      http.request(req)
+    end
+  end
+end

--- a/plans/session_token.pp
+++ b/plans/session_token.pp
@@ -1,0 +1,7 @@
+plan bolt_train::session_token(
+  TargetSpec $targets,
+  String[1] $email
+ ){
+   $token_result = run_task('bolt_train::session', $targets, 'email' => $email)
+   return $token_result[0].value['token']
+ }

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  train:
+    container_name: train
+    image: pcr-internal.puppet.net/dimitri.tischenko/bolt-train-api:latest
+    network_mode: host
+    volumes:
+      - /tmp/bolt-train-queue:/bolt-train-queue
+    ports:
+      - "5000:5000"

--- a/spec/fixtures/test/plans/init.yaml
+++ b/spec/fixtures/test/plans/init.yaml
@@ -1,0 +1,22 @@
+steps:
+  - name: session_token
+    description: Obtaining BoltTrain token with bolt_train::session_token plan.
+    plan: bolt_train::session_token
+    parameters:
+      email: cas.donoghue@puppet.com
+      targets: bolt-train
+  - name: forward
+    description: Move train forward with the bolt_train::move task. 
+    task: bolt_train::move
+    target: bolt-train
+    parameters:
+      token: $session_token
+      direction: forward
+      speed: 10
+      time: 15
+  - name: run
+    description: Deploy my plan to the train!
+    task: bolt_train::run
+    target: bolt-train
+    parameters:
+      token: $session_token

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt_spec/run'
+require 'json'
+
+describe 'bolt_train integration' do
+  include BoltSpec::Run
+  let(:bolt_config) { { 'modulepath' => "#{RSpec.configuration.module_path}:#{File.join(Dir.pwd, 'spec/fixtures')}" } }
+  let(:bolt_inventory) do
+    {
+      'version' => 2,
+      'targets' => [
+        {
+          'name' => 'bolt-train',
+          'config' => {
+            'transport' => 'remote',
+            'remote' => {
+              'train_api_url' => 'https://localhost:5000'
+            }
+          }
+        }
+      ]
+    }
+  end
+  let(:output_dir) { '/tmp/bolt-train-queue' }
+
+  it 'runs a plan that hits all endpoints and creates a valid run file' do
+    plan_result = run_plan('test', {})
+    expect(plan_result).to include('status' => 'success')
+    last_modified = Dir.glob("#{output_dir}/*").max_by { |f| File.mtime(f) }
+    result = JSON.parse(File.read(last_modified))
+    expect(result).to include('session')
+    expect(result['session']).to include('commands')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'puppet_pal'
+
+# Ensure tasks are enabled when rspec-puppet sets up an environment
+# so we get task loaders.
+Puppet[:tasks] = true
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/tasks/move.json
+++ b/tasks/move.json
@@ -1,0 +1,24 @@
+{
+  "description": "Move Bolt Train",
+  "remote": true,
+  "files": ["ruby_task_helper/files/task_helper.rb", "bolt_train/lib/request_helper.rb"],
+  "input_method": "stdin",
+  "parameters": {
+    "token": {
+      "type": "String[1]",
+      "description": "Auth token"
+    },
+    "direction": {
+      "type": "Enum['forward', 'reverse']",
+      "description": "Direction to move train, acceptable values 'forward', 'reverse'"
+    },
+    "time": {
+      "type": "Integer[1, 30]",
+      "description": "Time in seconds for movement"
+    },
+    "speed": {
+      "type": "Integer[1, 10]",
+      "description": "Speed of movement"
+    }
+  }
+}

--- a/tasks/move.rb
+++ b/tasks/move.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../lib/request_helper.rb'
+require 'json'
+require 'open3'
+
+class BoltTrainMove < TaskHelper
+  def session(opts)
+    begin
+      uri = "#{opts[:_target][:train_api_url]}/command/move"
+      body = { direction: opts[:direction], speed: opts[:speed], time: opts[:time] }
+      resp = RequestHelper.request(uri, body, opts[:token])
+    rescue StandardError => e
+      # TODO: meaningful error handing
+      raise TaskHelper::Error.new(e.message, 'bolt-train/error')
+    end
+    JSON.parse(resp.body)
+  end
+
+  def task(opts)
+    session(opts)
+  end
+end
+
+BoltTrainMove.run if $PROGRAM_NAME == __FILE__

--- a/tasks/run.json
+++ b/tasks/run.json
@@ -1,0 +1,12 @@
+{
+  "description": "Deploy train plan",
+  "remote": true,
+  "files": ["ruby_task_helper/files/task_helper.rb", "bolt_train/lib/request_helper.rb"],
+  "input_method": "stdin",
+  "parameters": {
+    "token": {
+      "type": "String[1]",
+      "description": "Auth token"
+    }
+  }
+}

--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../lib/request_helper.rb'
+require 'json'
+require 'open3'
+
+class BoltTrainRun < TaskHelper
+  def session(opts)
+    begin
+      uri = "#{opts[:_target][:train_api_url]}/session/run"
+      body = {}
+      resp = RequestHelper.request(uri, body, opts[:token])
+    rescue StandardError => e
+      # TODO: meaningful error handing
+      raise TaskHelper::Error.new(e.message, 'bolt-train/error')
+    end
+    JSON.parse(resp.body)
+  end
+
+  def task(opts)
+    session(opts)
+  end
+end
+
+BoltTrainRun.run if $PROGRAM_NAME == __FILE__

--- a/tasks/session.json
+++ b/tasks/session.json
@@ -1,0 +1,12 @@
+{
+  "description": "Request Bolt Train session key",
+  "remote": true,
+  "files": ["ruby_task_helper/files/task_helper.rb", "bolt_train/lib/request_helper.rb"],
+  "input_method": "stdin",
+  "parameters": {
+    "email": {
+      "type": "String[1]",
+      "description": "Email address to log in with."
+    }
+  }
+}

--- a/tasks/session.rb
+++ b/tasks/session.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../lib/request_helper.rb'
+require 'json'
+require 'open3'
+
+class BoltTrainSession < TaskHelper
+  def session(opts)
+    begin
+      uri = "#{opts[:_target][:train_api_url]}/session/create"
+      body = { email: opts[:email] }
+      resp = RequestHelper.request(uri, body)
+    rescue StandardError => e
+      # TODO: meaningful error handing
+      raise TaskHelper::Error.new(e.message, 'bolt-train/error')
+    end
+    JSON.parse(resp.body)
+  end
+
+  def task(opts)
+    session(opts)
+  end
+end
+
+BoltTrainSession.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
This commit is a fully formed module based on the proposal in https://github.com/puppetlabs/bolt-train-api/pull/1 . There is an interface for making calls to the bolt-train-api using bolt task/plan content.